### PR TITLE
Fixed: Autodiscovery MCPToolset bug

### DIFF
--- a/mcp_server/djangomcp.py
+++ b/mcp_server/djangomcp.py
@@ -343,7 +343,9 @@ class ToolsetMeta(type):
         global mqs_dep_warned
         super().__init__(name, bases, namespace)
         # Skip base class itself
-        if name == "MCPToolset":
+        if name != "MCPToolset" and (
+            bases and MCPToolset in bases or any(issubclass(base, MCPToolset) for base in bases if isinstance(base, type))
+        ):
             ToolsetMeta.registry[name] = cls
 
     @staticmethod

--- a/mcp_server/djangomcp.py
+++ b/mcp_server/djangomcp.py
@@ -343,9 +343,7 @@ class ToolsetMeta(type):
         global mqs_dep_warned
         super().__init__(name, bases, namespace)
         # Skip base class itself
-        if name != "MCPToolset" and (
-            bases and MCPToolset in bases or any(issubclass(base, MCPToolset) for base in bases if isinstance(base, type))
-        ):
+        if name != "MCPToolset" and issubclass(cls, MCPToolset):
             ToolsetMeta.registry[name] = cls
 
     @staticmethod


### PR DESCRIPTION
The check should be `!=`.
Also added checks for inherited classes.