### PR TITLE
Correct secondary MCP usage and update example app

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,10 +382,11 @@ work here..
 ### Secondary MCP endpoint
 in `mcp.py`
 ```python
+from mcp_server.djangomcp import DjangoMCP
 
 second_mcp = DjangoMCP(name="altserver")
 
-@second_mcp.tools()
+@second_mcp.tool()
 async def my_tool():
     ...
 ```
@@ -393,7 +394,9 @@ async def my_tool():
 in urls.py 
 ```python
 ...
-    path("altmcp", MCPServerStreamableHttpView.as_view(mcp_server=second_server))
+from yourapp.mcp import second_mcp
+...
+path("altmcp", MCPServerStreamableHttpView.as_view(mcp_server=second_mcp))
 ...
 ```
 

--- a/examples/mcpexample/bird_counter/mcp.py
+++ b/examples/mcpexample/bird_counter/mcp.py
@@ -66,6 +66,15 @@ async def get_species_count(name : str):
 
     return ret.count
 
+# To create a secondary MCP endpoint with its own isolated toolset, you can use the DjangoMCP constructor
+from mcp_server.djangomcp import DjangoMCP
+
+second_mcp = DjangoMCP(name="altserver")
+
+@second_mcp.tool()
+async def get_bird_news():
+    """ Get the latest bird news """
+    return "Scientists have discovered a new bird species!"
 
 drf_publish_create_mcp_tool(LocationAPIView)
 

--- a/examples/mcpexample/mcpexample/urls.py
+++ b/examples/mcpexample/mcpexample/urls.py
@@ -21,10 +21,11 @@ from rest_framework.decorators import api_view, permission_classes, authenticati
 from rest_framework.permissions import IsAuthenticated
 
 from mcp_server.views import MCPServerStreamableHttpView
+from bird_counter.mcp import second_mcp
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("", include('mcp_server.urls')),
-    path("mcpunsecured", MCPServerStreamableHttpView.as_view())
-
+    path("mcpunsecured", MCPServerStreamableHttpView.as_view()),
+    path("altmcp", MCPServerStreamableHttpView.as_view(mcp_server=second_mcp))
 ]


### PR DESCRIPTION
Fixed incorrect tool definition of secondary MCP endpoint in the documentation + documented DjangoMCP import.
Updated the bird app example to include a configured secondary MCP server with an isolated toolset.