### PR TITLE
Add Claude local memory files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,6 @@ contrib
 .idea
 
 .env
+
+# Claude local settings
+Claude.local.md


### PR DESCRIPTION
This is a housekeeping change that improves the developer experience when using Claude Code with this repository.

**Changes**

- Added CLAUDE.local.md pattern to .gitignore

**Rationale**

When using Claude Code to write code in django-mcp-server, I might want to tell Claude to "remember" things related to what we're working on. Claude puts this info in `CLAUDE.local.md` by adding these files to `.gitignore`, we ensure that developers can use Claude Code's memory features without cluttering the repository. Note that `CLAUDE.md` is NOT ignored so that if one day we want to start creating and committing shared Claude documentation, we can.