### PR TITLE
Fix DRF Integration Body Processing and API Failure Issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,6 @@ contrib
 .idea
 
 .env
+
+# Claude local settings
+Claude.local.md


### PR DESCRIPTION
## Summary

This PR fixes critical bugs in the Django REST Framework integration and adopts a cleaner architectural approach using composition over method patching.

## Bugs Fixed

### 1. **Body Parameter Mapping Issue**

- **Github Issue Link:** https://github.com/omarbenhamid/django-mcp-server/issues/39
- **Problem**: MCP tool calls made with data nested inside a body property (e.g., `{"body": {"title": "...", "content": "..."}}`) were not being properly extracted for DRF serializers
- **Symptom**: DRF validation errors showing required fields as missing, even though they were present in the MCP call
- **Root Cause**: The request initialization flow was returning the original MCP JSON-RPC request instead of the fabricated request containing the extracted body data
- **Fix**: Proper data flow from MCP body parameters to DRF serializer data

### 2. **Global ViewSet Patching Breaking Normal HTTP Requests**

- **Github Issue Link:** https://github.com/omarbenhamid/django-mcp-server/issues/32
- **Problem**: The `initialize_request` method was being globally patched on ViewSet classes, affecting ALL requests to those ViewSets, including normal API requests
- **Symptom**: Normal HTTP API requests (e.g., `curl localhost:8000/posts/`) failed with `AttributeError: 'WSGIRequest' object has no attribute 'original_request'`
- **Root Cause**: Method patching modified the class permanently, expecting MCP-specific request attributes on normal Django requests
- **Fix**: MCP requests conform to the same interface expectations as normal API requests and patching has been removed all together

## Technical Strategy

Instead of trying to bypass or hack DRF's request creation, we pre-process the MCP request into exactly what DRF expects (a simple Django HttpRequest) and then let DRF run its full lifecycle using its intended mechanisms.

The benefits of this approach are:

1. Let DRF's unmodified initialize_request do its job naturally
2. DRF creates a proper rest_framework.request.Request with all the bells and whistles
3. Full DRF lifecycle runs: parsers, authentication, permissions, etc.

The potential drawbacks are:

1. We are using a Factory from DRF's testing library, which is certainly intended to be used for runtime purposes. In future version of DRF this may break (as the factory is likely to be extended to suit new testing needs).

## Demo / Testing

Here are screenshots of my really simple Blog Post app (see code [here](https://github.com/omarbenhamid/django-mcp-server/issues/39)) working with Claude Desktop: 
<img width="1136" height="1056" alt="LIST" src="https://github.com/user-attachments/assets/023c1e79-ba81-4c21-a40f-0d2f931a06b2" />
<img width="1136" height="1056" alt="CREATE" src="https://github.com/user-attachments/assets/5a410756-2dbe-428f-8d09-19890769ac67" />
<img width="1136" height="1056" alt="UPDATE" src="https://github.com/user-attachments/assets/ab87ec75-4a0c-4a18-a562-a9ccfdaabbe7" />
<img width="1136" height="1056" alt="DESTROY" src="https://github.com/user-attachments/assets/c1ce3340-7aae-4414-9de0-532e2696a583" />
<img width="1136" height="1056" alt="LIST_FINAL" src="https://github.com/user-attachments/assets/e7deb35a-4db5-441d-8691-8e9e08bacf03" />

Here's my really simple Blog Post app normal API calls working:  
<img width="885" height="777" alt="Standard_API_Call" src="https://github.com/user-attachments/assets/12a301d1-61f1-4590-98bb-ead7b419e9ad" />

All tests in the bird_counter example app pass: <img width="885" height="777" alt="Screenshot 2025-08-07 at 11 04 03 PM" src="https://github.com/user-attachments/assets/a54ee9dd-6367-4673-95fe-bafd6dd579cf" />