### PR TITLE
#33 Fix warning with drf-spectacular

### DIFF
--- a/mcp_server/views.py
+++ b/mcp_server/views.py
@@ -1,10 +1,7 @@
-from django.conf import settings
 from django.http import HttpResponse
-from django.shortcuts import render
 from django.utils.decorators import method_decorator
-from django.views import View
 from django.views.decorators.csrf import csrf_exempt
-from mcp.server import FastMCP
+from drf_spectacular.utils import extend_schema
 from rest_framework.views import APIView
 
 from mcp_server.djangomcp import global_mcp_server
@@ -14,12 +11,15 @@ from mcp_server.djangomcp import global_mcp_server
 class MCPServerStreamableHttpView(APIView):
     mcp_server = global_mcp_server
 
+    @extend_schema(exclude=True)
     def get(self, request, *args, **kwargs):
         return self.mcp_server.handle_django_request(request)
 
+    @extend_schema(exclude=True)
     def post(self, request, *args, **kwargs):
         return self.mcp_server.handle_django_request(request)
 
+    @extend_schema(exclude=True)
     def delete(self, request, *args, **kwargs):
         self.mcp_server.destroy_session(request)
         return HttpResponse(status=200, content="Session destroyed")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "mcp (>=1.8.0)",
     "django (>=4.0)",
     "djangorestframework (>=3.15.0)",
+    "drf-spectacular (>=0.28.0)",
     "inflection (>=0.5.1,<0.6.0)",
     "uritemplate (>=4.1.1,<5.0.0)",
 ]
@@ -39,4 +40,3 @@ pytest-django = "^4.11.1"
 uvicorn = "^0.34.3"
 djangorestframework-csv = "^3.0.2"
 drf-excel = "^2.5.3"
-


### PR DESCRIPTION
This adds `@extend_schema(exclude=True)` as suggested in https://github.com/omarbenhamid/django-mcp-server/issues/33#issuecomment-3172043658.

It also cleans up a few unused `import`s.

Closes #33.