### PR TITLE
fix: implement server instructions tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ Refer to this [list of clients](https://modelcontextprotocol.io/clients)
    - stateless : when set to 'True' the server will not manage sessions 
 
 - **DJANGO_MCP_AUTHENTICATION_CLASSES** (default to no authentication) a list of reference to Django Rest Framework authentication classes to enfors in the main MCP view.
-- **DJANGO_MCP_GET_SERVER_INSTRUCTIONS_TOOL** (default=True) if true a tool will be offered to obtain global instruction  and tools will instruct the agent o use it, as agents do not always have the MCP server glboal instructions incldued in their system prompt.
+- **DJANGO_MCP_GET_SERVER_INSTRUCTIONS_TOOL** (default=True) if true a tool will be offered to obtain global instruction and tools will instruct the agent to use it, as agents do not always have the MCP server global instructions included in their system prompt.
 
 ## Roadmap
 

--- a/mcp_server/djangomcp.py
+++ b/mcp_server/djangomcp.py
@@ -168,6 +168,17 @@ class DjangoMCP(FastMCP):
         self.stateless = stateless
         engine = import_module(settings.SESSION_ENGINE)
         self.SessionStore = engine.SessionStore
+        
+        # Optionally publish a tool that returns the global server instructions
+        if getattr(settings, "DJANGO_MCP_GET_SERVER_INSTRUCTIONS_TOOL", True):
+            async def _get_server_instructions():
+                return self._mcp_server.instructions or ""
+
+            self._tool_manager.add_tool(
+                fn=_get_server_instructions,
+                name="get_server_instructions",
+                description="Return MCP server instructions (if any). Always call first."
+            )
 
     @property
     def session_manager(self) -> StreamableHTTPSessionManager:


### PR DESCRIPTION
The README reads as follows:

> DJANGO_MCP_GET_SERVER_INSTRUCTIONS_TOOL (default=True) if true a tool will be offered to obtain global instruction and tools will instruct the agent to use it, as agents do not always have the MCP server glboal instructions incldued in their system prompt.

However, I could not find any such functionality in the whole codebase. Maybe it was forgotten? If I just missed, it somehow, please let me know and close this PR.

This PR fixes this by checking the DJANGO_MCP_GET_SERVER_INSTRUCTIONS_TOOL variable and if it is set to True (which it is by default) it will create a "get_server_instructions" tool which returns the server instructions, just like the README indicates.

As a result the agents will check this tool before doing anything:

<img width="418" height="38" alt="image" src="https://github.com/user-attachments/assets/bf979af7-4373-4de5-930b-d4631a776b80" />

PS. I could not find any contribution guidelines in this project, let me know if I missed something and I'll adapt.

