### PR TITLE
feat: add DJANGO_MCP_SERVER_CLASS setting to allow custom DjangoMCP subclass

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,27 @@ MCPServerStreamableHttpView.as_view(permission_classes=[IsAuthenticated], authen
 ...
 ```
 
+### Custom MCP Server Class
+
+You can create a custom MCP server class by subclassing `DjangoMCP` and configuring it in your settings:
+
+In your `mcp.py` or any module:
+```python
+from mcp_server.djangomcp import DjangoMCP
+
+class CustomMCPServer(DjangoMCP):
+    def register_drf_list_tool(self, ...):
+        # Custom tool registration
+        ...        
+```
+
+In `settings.py`:
+```python
+DJANGO_MCP_SERVER_CLASS = "yourapp.mcp.CustomMCPServer"
+```
+
+This allows you to customize the MCP server behavior for your specific needs.
+
 ## Testing
 
 ### The server
@@ -468,6 +489,8 @@ Refer to this [list of clients](https://modelcontextprotocol.io/clients)
    - name: a  name for the server
    - instructions: global instructions
    - stateless : when set to 'True' the server will not manage sessions 
+
+- **DJANGO_MCP_SERVER_CLASS** (default="mcp_server.djangomcp.DjangoMCP") a dotted path to a custom MCP server class. The class must be a subclass of `DjangoMCP`. This allows you to customize the MCP server behavior by creating your own subclass.
 
 - **DJANGO_MCP_AUTHENTICATION_CLASSES** (default to no authentication) a list of reference to Django Rest Framework authentication classes to enfors in the main MCP view.
 - **DJANGO_MCP_GET_SERVER_INSTRUCTIONS_TOOL** (default=True) if true a tool will be offered to obtain global instruction and tools will instruct the agent to use it, as agents do not always have the MCP server global instructions included in their system prompt.

--- a/mcp_server/djangomcp.py
+++ b/mcp_server/djangomcp.py
@@ -20,6 +20,8 @@ from rest_framework.serializers import Serializer
 from rest_framework.test import APIRequestFactory
 from starlette.datastructures import Headers
 from starlette.types import Scope, Receive, Send
+from django.utils.module_loading import import_string
+from django.core.exceptions import ImproperlyConfigured
 
 if TYPE_CHECKING:
     pass
@@ -386,7 +388,16 @@ class DjangoMCP(FastMCP):
         tool.fn = sync_to_async(_DRFDeleteAPIViewCallerTool(self, view_class, actions=actions))
 
 
-global_mcp_server = DjangoMCP(**getattr(settings, 'DJANGO_MCP_GLOBAL_SERVER_CONFIG', {}))
+_mcp_server_class = import_string(
+    getattr(settings, 'DJANGO_MCP_SERVER_CLASS', 'mcp_server.djangomcp.DjangoMCP')
+)
+
+if not issubclass(_mcp_server_class, DjangoMCP):
+    raise ImproperlyConfigured(
+        f"DJANGO_MCP_SERVER_CLASS must be a subclass of DjangoMCP, got {_mcp_server_class}"
+    )
+
+global_mcp_server = _mcp_server_class(**getattr(settings, 'DJANGO_MCP_GLOBAL_SERVER_CONFIG', {}))
 
 
 class ToolsetMeta(type):


### PR DESCRIPTION
## Problem
`global_mcp_server` is hardcoded to use `DjangoMCP`, making it impossible 
to use a custom subclass without monkey-patching the module.

This is a common need when users want to override methods like 
`register_drf_list_tool` to add custom behavior (e.g. extra params, 
custom serialization, pagination support).

## Solution
Add a `DJANGO_MCP_SERVER_CLASS` setting following Django's `import_string` 
pattern, allowing users to provide their own `DjangoMCP` subclass.

## Usage
```python
# settings.py
DJANGO_MCP_SERVER_CLASS = 'myapp.mcp.MyCustomDjangoMCP'
```

## Notes
- Fully backwards compatible — defaults to `DjangoMCP` if not set
- Validates that the custom class is a subclass of `DjangoMCP` and raises 
  `ImproperlyConfigured` if not
- Follows Django's existing conventions (`import_string`, `ImproperlyConfigured`)