### PR TITLE
feat: forward icons parameter to FastMCP (closes #58)

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,10 +317,15 @@ async def increment_species(name: str, amount: int = 1) -> int:
 In `settings.py` you can initialize the `DJANGO_MCP_GLOBAL_SERVER_CONFIG` parameter. These will be 
 passed to the `MCPServer` server during initialization
 ```python
+from mcp.types import Icon
+
 DJANGO_MCP_GLOBAL_SERVER_CONFIG = {
     "name":"mymcp",
     "instructions": "Some instructions to use this server",
-    "stateless": False
+    "stateless": False,
+    "icons": [
+        Icon(src="https://example.com/icon.png", mimeType="image/png", sizes=["64x64"]),
+    ],
 }
 ```
 
@@ -467,7 +472,8 @@ Refer to this [list of clients](https://modelcontextprotocol.io/clients)
 - **DJANGO_MCP_GLOBAL_SERVER_CONFIG** a configuration dictionnary for the global MCP server default to empty. It can include the following parmaters
    - name: a  name for the server
    - instructions: global instructions
-   - stateless : when set to 'True' the server will not manage sessions 
+   - stateless : when set to 'True' the server will not manage sessions
+   - icons: optional list of `mcp.types.Icon` instances advertised to clients (e.g. shown by Claude Desktop next to the server name). Requires `mcp >= 1.15.0`.
 
 - **DJANGO_MCP_AUTHENTICATION_CLASSES** (default to no authentication) a list of reference to Django Rest Framework authentication classes to enfors in the main MCP view.
 - **DJANGO_MCP_GET_SERVER_INSTRUCTIONS_TOOL** (default=True) if true a tool will be offered to obtain global instruction and tools will instruct the agent to use it, as agents do not always have the MCP server global instructions included in their system prompt.

--- a/examples/mcpexample/bird_counter/tests.py
+++ b/examples/mcpexample/bird_counter/tests.py
@@ -1,8 +1,10 @@
 from django.db.models import Q
 from django.test import TestCase
+from mcp.types import Icon
 
 from .models import Bird, Location, City
 from mcp_server import query_tool
+from mcp_server.djangomcp import DjangoMCP
 
 
 class JSONQueryTest(TestCase):
@@ -353,3 +355,16 @@ class JSONQueryTest(TestCase):
         self.assertEqual(3, row["min_count"])
         self.assertEqual(2, row["count"] )
         self.assertEqual(4, row["average"])
+
+
+class DjangoMCPIconsTest(TestCase):
+    """Regression tests for the icons argument forwarded to FastMCP (issue #58)."""
+
+    def test_icons_default_is_none(self):
+        server = DjangoMCP(name="icons-default")
+        self.assertIsNone(server._mcp_server.icons)
+
+    def test_icons_forwarded_to_fastmcp(self):
+        icons = [Icon(src="https://example.com/icon.png", mimeType="image/png", sizes=["64x64"])]
+        server = DjangoMCP(name="icons-forwarded", icons=icons)
+        self.assertEqual(server._mcp_server.icons, icons)

--- a/mcp_server/djangomcp.py
+++ b/mcp_server/djangomcp.py
@@ -15,6 +15,7 @@ from django.db.models import QuerySet
 from django.http import HttpResponse, HttpRequest
 from mcp.server import FastMCP
 from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+from mcp.types import Icon
 from rest_framework.mixins import CreateModelMixin, UpdateModelMixin, DestroyModelMixin, ListModelMixin
 from rest_framework.serializers import Serializer
 from rest_framework.test import APIRequestFactory
@@ -163,9 +164,9 @@ MCP_SESSION_ID_HDR = "Mcp-Session-Id"
 # Stuff pulled to support embedded server ?
 class DjangoMCP(FastMCP):
 
-    def __init__(self, name=None, instructions=None, stateless=False):
+    def __init__(self, name=None, instructions=None, stateless=False, icons: list[Icon] | None = None):
         # Prevent extra server settings as we do not use the embedded server
-        super().__init__(name or "django_mcp_server", instructions)
+        super().__init__(name or "django_mcp_server", instructions, icons=icons)
         self.stateless = stateless
         engine = import_module(settings.SESSION_ENGINE)
         self.SessionStore = engine.SessionStore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ documentation = "https://github.com/omarbenhamid/django-mcp-server"
 keywords = ["django", "mcp", "model context protocol", "tools"]
 requires-python = ">=3.10"
 dependencies = [
-    "mcp (>=1.8.0)",
+    "mcp (>=1.15.0)",
     "django (>=4.0)",
     "djangorestframework (>=3.15.0)",
     "inflection (>=0.5.1,<0.6.0)",


### PR DESCRIPTION
## Summary

Closes #58.

- `DjangoMCP.__init__` now accepts an optional `icons: list[Icon] | None` kwarg and forwards it to `FastMCP.__init__`, so MCP clients (e.g. Claude Desktop) can display a server icon next to the server name.
- The option is also usable via `DJANGO_MCP_GLOBAL_SERVER_CONFIG`:
  ```python
  from mcp.types import Icon

  DJANGO_MCP_GLOBAL_SERVER_CONFIG = {
      "name": "mymcp",
      "icons": [
          Icon(src="https://example.com/icon.png", mimeType="image/png", sizes=["64x64"]),
      ],
  }
  ```
- The `icons` keyword was introduced in `mcp` **1.15.0** ([SEP 973](https://github.com/modelcontextprotocol/python-sdk/pull/1357)), so the lower bound on the `mcp` dependency is bumped from `1.8.0` to `1.15.0`. Latest `mcp` today is `1.27.0`, so this is a conservative floor.
- README updated: new bullet under the `DJANGO_MCP_GLOBAL_SERVER_CONFIG` settings reference and an example in the "Customize the default MCP server settings" section.

No change to existing behavior when `icons` is omitted (default `None` is accepted by `FastMCP`).

## Test plan

- [x] New `DjangoMCPIconsTest` in `examples/mcpexample/bird_counter/tests.py`:
  - `test_icons_default_is_none` — constructing without `icons` keeps `_mcp_server.icons` as `None`.
  - `test_icons_forwarded_to_fastmcp` — passing `icons=[...]` propagates the list to the underlying `MCPServer`.
- [x] `pytest` in `examples/mcpexample/` — all 10 tests pass (8 existing + 2 new).
- [x] `python manage.py check` on the example project — clean.