### PR TITLE
fix: use Count("pk") to support models with custom primary key (closes #65)

### DIFF
--- a/mcp_server/query_tool.py
+++ b/mcp_server/query_tool.py
@@ -256,7 +256,7 @@ def apply_json_mango_query(queryset: QuerySet, pipeline: list[dict],
                 op, arg = next(iter(agg.items()))
                 if op == "$sum":
                     if arg == 1:
-                        annotations[key] = Count("id")
+                        annotations[key] = Count("pk")
                     elif isinstance(arg, str) and arg.startswith("$"):
                         annotations[key] = Sum(_translate_field(arg[1:], lookup_alias_map))
                     else:
@@ -279,7 +279,7 @@ def apply_json_mango_query(queryset: QuerySet, pipeline: list[dict],
 
                 elif op == "$count":
                     if arg == 1:
-                        annotations[key] = Count("id")
+                        annotations[key] = Count("pk")
                     elif isinstance(arg, str) and arg.startswith("$"):
                         annotations[key] = Count(_translate_field(arg[1:], lookup_alias_map))
                     else:


### PR DESCRIPTION
## Summary

- Replace `Count("id")` with `Count("pk")` in the `$group` stage handler of `apply_json_mango_query` (both `$sum: 1` and `$count: 1` branches).
- Django's `pk` alias resolves to the actual primary key field regardless of its name, so this works uniformly whether the model uses the default `id` field or a custom primary key (e.g. `UUIDField(primary_key=True)`).

Closes #65.

## Test plan

- [ ] Define a model with a custom primary key (e.g. `uuid = models.UUIDField(primary_key=True)`).
- [ ] Run a pipeline containing `{"$group": {"_id": null, "total": {"$count": 1}}}` and confirm it returns a result instead of raising `FieldError: Cannot resolve keyword 'id' into field`.
- [ ] Run the same pipeline with `{"$sum": 1}` and confirm the same.
- [ ] Confirm existing models with a default `id` primary key still behave identically.